### PR TITLE
Fix api refactoring renames vs argment to vspd

### DIFF
--- a/PyDodo/pydodo/aircraft_control.py
+++ b/PyDodo/pydodo/aircraft_control.py
@@ -40,7 +40,7 @@ def change_altitude(aircraft_id, altitude=None, flight_level=None, vertical_spee
 
     if vertical_speed:
         utils._validate_speed(vertical_speed)
-        body["vs"] = vertical_speed
+        body["vspd"] = vertical_speed
     return post_request(config_param("endpoint_change_altitude"), body)
 
 

--- a/PyDodo/pydodo/async_aircraft_control.py
+++ b/PyDodo/pydodo/async_aircraft_control.py
@@ -91,7 +91,7 @@ async def async_change_altitude(
     body = {config_param("query_aircraft_id"): aircraft_id, "alt": alt}
     if vertical_speed:
         utils._validate_speed(vertical_speed)
-        body["vs"] = vertical_speed
+        body["vspd"] = vertical_speed
     async with aiohttp.ClientSession(raise_for_status=True) as session:
         url = construct_endpoint_url(config_param("endpoint_change_altitude"))
         async with session.post(url, json=body) as response:


### PR DESCRIPTION
Renames vs argment to vspd
as stated in https://github.com/project-bluebird/bluebird/blob/master/docs/api-v2-changes.md

From a search of "vs" it looks like the R library also needs changing, both in `./rdodo/R/change_altitude.R` and some of the tests? I'm not familiar with R or the testing, so I've left it.

Closes https://github.com/project-bluebird/dodo/issues/117